### PR TITLE
Add ECR repository and GitHub Actions role

### DIFF
--- a/envs/prod/ecr.tf
+++ b/envs/prod/ecr.tf
@@ -1,0 +1,32 @@
+locals {
+  ecr_tags = {
+    Project     = var.project
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}
+
+resource "aws_ecr_repository" "application" {
+  name                 = var.ecr_repository_name
+  image_tag_mutability = "MUTABLE"
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = local.ecr_tags
+}
+
+module "github_actions_oidc" {
+  source = "../../modules/iam_github_oidc"
+
+  github_owner       = var.github_owner
+  github_repository  = var.github_repository
+  role_name          = var.github_oidc_role_name
+  allowed_ecr_arns   = [aws_ecr_repository.application.arn]
+  tags               = local.ecr_tags
+}

--- a/envs/prod/output.tf
+++ b/envs/prod/output.tf
@@ -1,0 +1,24 @@
+output "eks_cluster_name" {
+  description = "Name of the EKS cluster."
+  value       = module.eks.cluster_name
+}
+
+output "eks_cluster_endpoint" {
+  description = "API server endpoint for the EKS cluster."
+  value       = module.eks.cluster_endpoint
+}
+
+output "eks_cluster_certificate_authority_data" {
+  description = "Certificate authority data required to authenticate to the cluster."
+  value       = module.eks.cluster_certificate_authority_data
+}
+
+output "ecr_repository_url" {
+  description = "URL of the ECR repository used by the application."
+  value       = aws_ecr_repository.application.repository_url
+}
+
+output "github_actions_role_arn" {
+  description = "IAM role ARN assumed by GitHub Actions workflows."
+  value       = module.github_actions_oidc.role_arn
+}

--- a/envs/prod/variables.tf
+++ b/envs/prod/variables.tf
@@ -1,0 +1,39 @@
+variable "region" {
+  description = "AWS region where the infrastructure will be provisioned."
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "project" {
+  description = "Project name used for resource naming and tagging."
+  type        = string
+  default     = "cap"
+}
+
+variable "environment" {
+  description = "Environment name used for resource naming and tagging."
+  type        = string
+  default     = "test"
+}
+
+variable "ecr_repository_name" {
+  description = "Name of the ECR repository that stores application images."
+  type        = string
+  default     = "cap-application"
+}
+
+variable "github_owner" {
+  description = "GitHub organization or user that owns the application repository."
+  type        = string
+}
+
+variable "github_repository" {
+  description = "GitHub repository that builds and pushes images."
+  type        = string
+}
+
+variable "github_oidc_role_name" {
+  description = "IAM role name assumed by GitHub Actions for pushing to ECR."
+  type        = string
+  default     = "github-actions-ecr"
+}

--- a/modules/iam_github_oidc/main.tf
+++ b/modules/iam_github_oidc/main.tf
@@ -1,0 +1,77 @@
+locals {
+  provider_host = replace(var.oidc_provider_url, "https://", "")
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = var.oidc_provider_url
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [var.oidc_thumbprint]
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.provider_host}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${local.provider_host}:sub"
+      values   = ["repo:${var.github_owner}/${var.github_repository}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github" {
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "ecr" {
+  statement {
+    sid = "AuthorizeECR"
+
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "PushPullECR"
+
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
+      "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+
+    resources = var.allowed_ecr_arns
+  }
+}
+
+resource "aws_iam_role_policy" "github_ecr" {
+  name   = "${var.role_name}-ecr"
+  role   = aws_iam_role.github.id
+  policy = data.aws_iam_policy_document.ecr.json
+}

--- a/modules/iam_github_oidc/outputs.tf
+++ b/modules/iam_github_oidc/outputs.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  description = "ARN of the IAM role assumed by GitHub Actions."
+  value       = aws_iam_role.github.arn
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider."
+  value       = aws_iam_openid_connect_provider.github.arn
+}

--- a/modules/iam_github_oidc/variables.tf
+++ b/modules/iam_github_oidc/variables.tf
@@ -1,0 +1,38 @@
+variable "github_owner" {
+  description = "GitHub organization or user that owns the repository."
+  type        = string
+}
+
+variable "github_repository" {
+  description = "Name of the GitHub repository that will assume the role."
+  type        = string
+}
+
+variable "role_name" {
+  description = "Name to assign to the IAM role used by GitHub Actions."
+  type        = string
+  default     = "github-actions-ecr"
+}
+
+variable "oidc_provider_url" {
+  description = "URL for the GitHub Actions OIDC provider."
+  type        = string
+  default     = "https://token.actions.githubusercontent.com"
+}
+
+variable "oidc_thumbprint" {
+  description = "Thumbprint for the GitHub Actions OIDC provider."
+  type        = string
+  default     = "6938fd4d98bab03faadb97b34396831e3780aea1"
+}
+
+variable "allowed_ecr_arns" {
+  description = "List of ECR repository ARNs that GitHub Actions workflows can access."
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "Tags to apply to created IAM resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- create a reusable module that provisions the GitHub Actions OIDC provider and IAM role with ECR permissions
- add configurable variables and outputs in the prod environment to surface repository and role details
- provision an application ECR repository with scanning enabled and wire it to the GitHub Actions role

## Testing
- Not run (Terraform CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f240657314832895e7f40add089452